### PR TITLE
Temporarily disabling cache

### DIFF
--- a/search.py
+++ b/search.py
@@ -23,8 +23,9 @@ class Search():
 
     def __init__(self) -> None:
         load_dotenv()
-        langchain.llm_cache = MilvusSemanticCache(
-            embedding=OpenAIEmbeddings(), score_threshold=0.12)
+        # Temporarily disabling cache
+        # langchain.llm_cache = MilvusSemanticCache(
+        #     embedding=OpenAIEmbeddings(), score_threshold=0.12)
 
 
     def search(self, candidate_name: str = "milei", query: str = None):


### PR DESCRIPTION
We need to cache the LLM answers by candidate. This change will happen in an upcoming PR. Disabling caching for now.